### PR TITLE
Compatibility: add noop range argument to hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,11 +235,14 @@ function Bytespace(db, ns, opts) {
       }
     }
 
-    space.pre = function (hook) {
+    space.pre = function (range, hook) {
+      // range is not (yet) implemented but here for sublevel compatibility
+      if (typeof range === 'function') hook = range
       return addHook(ns.prehooks, hook)
     }
 
-    space.post = function (hook) {
+    space.post = function (range, hook) {
+      if (typeof range === 'function') hook = range
       return addHook(ns.posthooks, hook)
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1240,4 +1240,30 @@ function run(dbFactory, hexNamespace, t) {
     })
 
   }))
+
+  t.test('precommit hooks, noop range argument', dbWrap(function (t, base) {
+    var db = subspace(base, 'test space 1', { valueEncoding: 'json' })
+
+    db.pre('this argument is ignored', function (op, add, ops) {
+      op.value*= 2
+    })
+
+    db.pre({ and: 'this too' }, function (op, add, ops) {
+      op.key = op.key.toUpperCase()
+    })
+
+    db.pre(function (op, add, ops) {
+      op.key+= op.key
+    })
+
+    db.put('foo', 2, function(err){
+      t.ifError(err, 'no put error')
+
+      db.get('FOOFOO', function(err, value){
+        t.ifError(err, 'no get error')
+        t.is(value, 4, 'value is doubled')
+        t.end()
+      })
+    })
+  }))
 }


### PR DESCRIPTION
This PR makes pre and post hooks accept a range argument. Not implemented, but simply ignored for compatibility with the level ecosystem. `db.pre(whatever, hook)`.is the same as `db.pre(hook)`.