### PR TITLE
Call post hooks on op.prefix (same as pre hooks)

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,11 +173,11 @@ function Bytespace(db, ns, opts) {
       cb = getCallback(opts, cb)
       opts = getOptions(opts)
 
-      function add(op) {    
-        if (op === false) {    
-          return delete ops[i]   
-        }    
-        ops.push(op)   
+      function add(op) {
+        if (op === false) {
+          return delete ops[i]
+        }
+        ops.push(op)
       }
 
       try {
@@ -217,14 +217,16 @@ function Bytespace(db, ns, opts) {
 
           // apply postcommit hooks for ops, setting encoded keys to initial state
           try {
-            if (ns.posthooks.length) {
-              ops.forEach(function (op) {
+            ops.forEach(function (op) {
+              var ns = op.prefix.namespace
+
+              if (ns.posthooks.length) {
                 ns.trigger(ns.posthooks, op.prefix, [ op ])
-              })
-            }
+              }
+            })
           }
           catch (err) {
-            cb(err)
+            return cb(err)
           }
 
           cb()

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags",
-    "test": "tape test | faucet"
+    "test": "tape test/*.js | faucet"
   },
   "repository": {
     "type": "git",

--- a/test/post-hooks.js
+++ b/test/post-hooks.js
@@ -1,0 +1,67 @@
+var levelup = require('levelup')
+var memdown = require('memdown')
+var test = require('tape')
+var bytespace = require('../')
+
+function factory() {
+  return bytespace(levelup(memdown))
+}
+
+test('post hooks, multiple namespaces', function(t){
+  t.plan(10)
+
+  var db = factory()
+  var sub1 = db.sublevel('sub1')
+  var sub2 = db.sublevel('sub2')
+  var called = []
+  var expected = ['root', 'sub1', 'sub2']
+
+  db.post(function(op){
+    called.push(op.key)
+    t.is(op.key, 'root', 'root hook')
+  })
+
+  sub1.post(function(op){
+    called.push(op.key)
+    t.is(op.key, 'sub1', 'sub1 hook')
+  })
+
+  sub2.post(function(op){
+    called.push(op.key)
+    t.is(op.key, 'sub2', 'sub2 hook')
+  })
+
+  db.batch([
+    { key: 'root', value: 'a' },
+    { key: 'sub1', prefix: sub1, value: 'b' },
+    { key: 'sub2', prefix: sub2, value: 'c' }
+  ], function(err){
+    t.ifError(err, 'no error')
+    t.same(called, expected, 'order')
+
+    called = []
+
+    sub2.batch([
+      { key: 'root', prefix: db, value: 'a' },
+      { key: 'sub1', prefix: sub1, value: 'b' },
+      { key: 'sub2', prefix: sub2, value: 'c' }
+    ], function(err){
+      t.ifError(err, 'no error')
+      t.same(called, expected, 'order')
+    })
+  })
+})
+
+test('post hook throwing error', function(t) {
+  t.plan(1)
+
+  var db = factory()
+
+  db.post(function(op){
+    throw new Error('beep')
+  })
+
+  db.put('a', 'a', function(err){
+    t.is(err.message, 'beep')
+  })
+})


### PR DESCRIPTION
Instead of calling the hooks of the bytespace db on which `batch` was called.

This makes post hooks behave the same as pre hooks, as well as the post hooks in `level-sublevel`. Here's [a gist](https://gist.github.com/vweevers/07daea4e6d5549f58648) that tests the behavior in sublevel and bytespace (also included in this PR as a tape test).